### PR TITLE
Update knot behavior

### DIFF
--- a/tests/test_smooth.py
+++ b/tests/test_smooth.py
@@ -87,6 +87,12 @@ class TestSmoothConBasics:
         smooth = SmoothCon("s(x0, bs='ps', k=8)", data=data)
         assert smooth.term == "x0"
 
+    def test_custom_knots(self) -> None:
+        knots = np.linspace(-4.4, 4.4, 12)
+        smooth = SmoothCon("s(x0, bs='ps', k=8)", data=data, knots=knots)
+
+        assert np.allclose(knots, smooth.knots)
+
 
 class TestSmoothFactory:
     def test_init(self) -> None:


### PR DESCRIPTION
1. Supplying custom knots was broken, it is not anymore.
2. The `SmoothCon.knots` attribute will now return the automatically defined knots from R, if `knots=None` (the default) is used. Before, it returned `None` in this case.